### PR TITLE
Replace text formatting regexes

### DIFF
--- a/src/utility/TextFormatter.cpp
+++ b/src/utility/TextFormatter.cpp
@@ -48,9 +48,9 @@ QString TextFormatter::format(QString const& input) {
 		throw InternalErrorException() << "Error on text- vs. link counts, we have " << remainingParts.size() << " text parts and " << linkList.size() << " links.";
 	}
 
-	static QRegularExpression regExpBold(QStringLiteral("\\*([^\\*\r\n]+)\\*"), patternOptions);
-	static QRegularExpression regExpItalic(QStringLiteral("_([^_\r\n]+)_"), patternOptions);
-	static QRegularExpression regExpStrikethrough(QStringLiteral("~([^~\r\n]+)~"), patternOptions);
+	static QRegularExpression regExpBold(QStringLiteral("\\B\\*([^\\r\\n]+?)\\*\\B"), patternOptions);
+	static QRegularExpression regExpItalic(QStringLiteral("\\b_([^\\r\\n]+?)_\\b"), patternOptions);
+	static QRegularExpression regExpStrikethrough(QStringLiteral("\\B~([^\\r\\n]+?)~\\B"), patternOptions);
 	static QRegularExpression regExpNewline(QStringLiteral("\\R"), patternOptions);
 
 	QString output;


### PR DESCRIPTION
The current version is still buggy with regard to word boundaries:

![img](http://tmp.dbrgn.ch/screenshots/20160719174234-51y9xrw2.png)

I replaced the regexes with the ones used by the Threema app itself. I only did very minor adjustments and am not sure whether there could be important differences between the Java and Qt implementations of the Regex engine, but [these tests](https://callumacrae.github.io/regex-tuesday/challenge4.html) all passed (using the proper formatting symbols of course).

It would probably be good if you could also test the Regexes thoroughly. Do you have a list of test strings?
