### PR TITLE
Fix unlocking database with no password

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -401,8 +401,11 @@ void Client::openDatabaseFile(QString const& fileName) {
 	QString password;
 	while (true) {
 		bool ok = false;
-		QString const password = QInputDialog::getText(this, tr("Database password"), tr("Please enter the database password for file \"%1\":").arg(fileName), QLineEdit::Password, QString(), &ok);
-		if (ok && !password.isNull()) {
+		QString password = QInputDialog::getText(this, tr("Database password"), tr("Please enter the database password for file \"%1\":").arg(fileName), QLineEdit::Password, QString(), &ok);
+		if (password.isNull()) {
+			password = QString("");
+		}
+		if (ok) {
 			QDir location(fileName);
 			location.cdUp();
 


### PR DESCRIPTION
I noticed a bug when I wanted to open a database with no password (`""`) where the software would cancel the operation instead of opening. This fixes it by assuming `""` when no String is entered.