### PR TITLE
Link openMittsuTests against pthread library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,7 +601,7 @@ target_link_libraries(openMittsuCore Qt5::Core Qt5::Network Qt5::Multimedia Qt5:
 target_link_libraries(openMittsu openMittsuCore Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network Qt5::Multimedia Qt5::MultimediaWidgets Qt5::Sql)
 target_link_libraries(openMittsuVersionInfo Qt5::Core)
 if (OPENMITTSU_ENABLE_TESTS)
-	target_link_libraries(openMittsuTests openMittsuCore Qt5::Core Qt5::Network Qt5::Multimedia Qt5::MultimediaWidgets Qt5::Sql gmock gtest)
+	target_link_libraries(openMittsuTests openMittsuCore Qt5::Core Qt5::Network Qt5::Multimedia Qt5::MultimediaWidgets Qt5::Sql gmock gtest pthread)
 endif (OPENMITTSU_ENABLE_TESTS)
 
 # Link against libc++abi if requested.


### PR DESCRIPTION
Otherwise, I get an error when linking openMittsuTests:
/usr/lib/gcc/x86_64-pc-linux-gnu/7.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/openMittsuTests.dir/test/src/MessageCenterTest.cpp.o: undefined reference to symbol 'pthread_setspecific@@GLIBC_2.2.5'